### PR TITLE
Add Day3: MLR Regularization notebook

### DIFF
--- a/Day3/Day3_MLR_Regularization.ipynb
+++ b/Day3/Day3_MLR_Regularization.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0a60a3b1-36d2-4f64-bf72-cabfe6ed952f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ridge Coefficients: [  157.10353026  6816.8145087  -5513.38922036]\n",
+      "Lasso Coefficients: [  158.213127    6867.56618016 -5363.4143967 ]\n",
+      "Ridge R2 Score: 0.9851777608273287\n",
+      "Lasso R2 Score: 0.9862436253558254\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from sklearn.linear_model import Ridge, Lasso\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import r2_score\n",
+    "\n",
+    "# Dataset (same as Day2)\n",
+    "data = {\n",
+    "    \"Size_sqft\": [1000, 1500, 2000, 2500, 3000, 1200, 1800, 2300, 2700, 3200],\n",
+    "    \"Bedrooms\":  [2,    3,    3,    4,    4,    2,    3,    4,    4,    5],\n",
+    "    \"Age_years\": [20,   15,   10,   8,    5,    25,   12,   7,    3,    1],\n",
+    "    \"Price\":     [300000, 400000, 500000, 600000, 700000, 320000, 480000, 580000, 650000, 780000]\n",
+    "}\n",
+    "\n",
+    "df = pd.DataFrame(data)\n",
+    "\n",
+    "# Features and target\n",
+    "X = df[[\"Size_sqft\", \"Bedrooms\", \"Age_years\"]]\n",
+    "y = df[\"Price\"]\n",
+    "\n",
+    "# Train-test split\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_state=42)\n",
+    "\n",
+    "# Ridge regression\n",
+    "ridge = Ridge(alpha=1.0)  # alpha = strength of regularization\n",
+    "ridge.fit(X_train, y_train)\n",
+    "\n",
+    "# Lasso regression\n",
+    "lasso = Lasso(alpha=1000)  # larger alpha = more shrinkage\n",
+    "lasso.fit(X_train, y_train)\n",
+    "\n",
+    "# Predictions\n",
+    "ridge_pred = ridge.predict(X_test)\n",
+    "lasso_pred = lasso.predict(X_test)\n",
+    "\n",
+    "print(\"Ridge Coefficients:\", ridge.coef_)\n",
+    "print(\"Lasso Coefficients:\", lasso.coef_)\n",
+    "\n",
+    "print(\"Ridge R2 Score:\", r2_score(y_test, ridge_pred))\n",
+    "print(\"Lasso R2 Score:\", r2_score(y_test, lasso_pred))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19a700b3-87a7-47c5-981c-cdcbf9095b9e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds the Day3 notebook covering Ridge & Lasso regression.
Includes:
- Implementation of Ridge & Lasso
- Comparison of coefficients
- R2 evaluation